### PR TITLE
Utf8

### DIFF
--- a/ListPorter/CommandLineParser.cs
+++ b/ListPorter/CommandLineParser.cs
@@ -1,6 +1,6 @@
 ﻿/*
  * ListPorter - Upload standard or extended .m3u playlist files to Plex Media Server.
- * Copyright (C) 2020-2025 Richard Lawrence
+ * Copyright (C) 2020-2026 Richard Lawrence
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -126,9 +126,15 @@ namespace ListPorter
                     i++;
                 }
                 else if (arg == "-u" || arg == "--unix" || arg == "--linux")  // Allow --linux as an alias for --unix
+                {
                     Globals.PathStyleOption = Globals.PathStyle.ForceLinux;
+                    ParsedFlags.Add("Unix");
+                }
                 else if (arg == "-w" || arg == "--windows")
+                {
                     Globals.PathStyleOption = Globals.PathStyle.ForceWindows;
+                    ParsedFlags.Add("Windows");
+                }
                 else if (arg == "-v" || arg == "--verbose")
                 {
                     Globals.VerboseMode = true;
@@ -182,14 +188,20 @@ namespace ListPorter
             if (Globals.PathToImport != null && !Directory.Exists(Globals.PathToImport) && !File.Exists(Globals.PathToImport))
                 ConsoleOutput.DisplayUsage($"Path to import does not exist ({Globals.PathToImport})");
 
-            // If path rewriting is enabled, turn off fuzzy path matching
+            // If FindText or BasePath is configured, then turn off fuzzy path matching.
 
-            if (!string.IsNullOrEmpty(Globals.FindText) || Globals.PathStyleOption != Globals.PathStyle.Auto || !string.IsNullOrEmpty(Globals.BasePath))
+            if (!string.IsNullOrEmpty(Globals.FindText) || !string.IsNullOrEmpty(Globals.BasePath))
             {
                 Globals.UsingPathRewriting = true;
                 Globals.UseFuzzyMatching = false;
                 Logger.Write("Path rewriting enabled, fuzzy path matching is disabled.", true);
             }
+
+            // If the user has defined --windows or --linux without any FindText or BasePath, then fuzzy matching will still be enabled
+            // and these options will be ignored.
+
+            if (Globals.UseFuzzyMatching == true && Globals.PathStyleOption != Globals.PathStyle.Auto)
+                Logger.Write("Warning: Forcing path style to " + (Globals.PathStyleOption == Globals.PathStyle.ForceWindows ? "Windows" : "Unix") + " will have no effect on fuzzy matching.", true);
         }
     }
 }

--- a/ListPorter/ConsoleOutput.cs
+++ b/ListPorter/ConsoleOutput.cs
@@ -1,6 +1,6 @@
 ﻿/*
  * ListPorter - Upload standard or extended .m3u playlist files to Plex Media Server.
- * Copyright (C) 2020-2025 Richard Lawrence
+ * Copyright (C) 2020-2026 Richard Lawrence
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/ListPorter/Globals.cs
+++ b/ListPorter/Globals.cs
@@ -1,6 +1,6 @@
 ﻿/*
  * ListPorter - Upload standard or extended .m3u playlist files to Plex Media Server.
- * Copyright (C) 2020-2025 Richard Lawrence
+ * Copyright (C) 2020-2026 Richard Lawrence
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/ListPorter/GrammarHelper.cs
+++ b/ListPorter/GrammarHelper.cs
@@ -1,6 +1,6 @@
 ﻿/*
  * ListPorter - Upload standard or extended .m3u playlist files to Plex Media Server.
- * Copyright (C) 2020-2025 Richard Lawrence
+ * Copyright (C) 2020-2026 Richard Lawrence
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/ListPorter/ListPorter.csproj
+++ b/ListPorter/ListPorter.csproj
@@ -14,13 +14,13 @@
 		<AssemblyTitle>Upload standard or extended .m3u playlist files to Plex Media Server</AssemblyTitle>
 		<PackageProjectUrl>https://github.com/mrsilver76/listporter</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/mrsilver76/listporter</RepositoryUrl>
-		<Copyright>Copyright © 2020-2025 Richard Lawrence</Copyright>
+		<Copyright>Copyright © 2020-2026 Richard Lawrence</Copyright>
 
 		<!-- Version information -->
 		<!-- Remember major.minor.BUILD.revision! -->
-		<Version>1.1.0.1</Version>
-		<AssemblyVersion>1.1.0.1</AssemblyVersion>
-		<FileVersion>1.1.0.1</FileVersion>
+		<Version>1.1.0.2</Version>
+		<AssemblyVersion>1.1.0.2</AssemblyVersion>
+		<FileVersion>1.1.0.2</FileVersion>
 		<AnalysisLevel>latest-recommended</AnalysisLevel>
 	</PropertyGroup>
 

--- a/ListPorter/Logger.cs
+++ b/ListPorter/Logger.cs
@@ -1,6 +1,6 @@
 ﻿/*
  * ListPorter - Upload standard or extended .m3u playlist files to Plex Media Server.
- * Copyright (C) 2020-2025 Richard Lawrence
+ * Copyright (C) 2020-2026 Richard Lawrence
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/ListPorter/PlaylistImporter.cs
+++ b/ListPorter/PlaylistImporter.cs
@@ -1,6 +1,6 @@
 ﻿/*
  * ListPorter - Upload standard or extended .m3u playlist files to Plex Media Server.
- * Copyright (C) 2020-2025 Richard Lawrence
+ * Copyright (C) 2020-2026 Richard Lawrence
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -107,7 +107,8 @@ namespace ListPorter
 
             foreach (var rawLine in lines)
             {
-                string line = rawLine.Trim();
+                // Trim whitespace and normalize the line to NFC form to ensure consistent handling of Unicode characters
+                string line = rawLine.Trim().Normalize(System.Text.NormalizationForm.FormC);
 
                 if (string.IsNullOrEmpty(line) || line.StartsWith('#') && !line.StartsWith("#PLAYLIST:", StringComparison.CurrentCulture))
                     continue;

--- a/ListPorter/PlexClient.cs
+++ b/ListPorter/PlexClient.cs
@@ -1,6 +1,6 @@
 ﻿/*
  * ListPorter - Upload standard or extended .m3u playlist files to Plex Media Server.
- * Copyright (C) 2020-2025 Richard Lawrence
+ * Copyright (C) 2020-2026 Richard Lawrence
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -142,7 +142,8 @@ namespace ListPorter
             foreach (var track in container.Elements("Track"))
             {
                 var media = track.Element("Media")?.Element("Part");
-                string? filePath = media?.Attribute("file")?.Value;
+                // Normalize the file path to NFC form to ensure consistent Unicode representation, which can help with matching tracks later on.
+                string? filePath = media?.Attribute("file")?.Value.Normalize(NormalizationForm.FormC);
                 string? ratingKeyStr = track.Attribute("ratingKey")?.Value;
 
                 bool isDeleted = media?.Attribute("deletedAt") != null;

--- a/ListPorter/PlexService.cs
+++ b/ListPorter/PlexService.cs
@@ -1,6 +1,6 @@
 ﻿/*
  * ListPorter - Upload standard or extended .m3u playlist files to Plex Media Server.
- * Copyright (C) 2020-2025 Richard Lawrence
+ * Copyright (C) 2020-2026 Richard Lawrence
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/ListPorter/Program.cs
+++ b/ListPorter/Program.cs
@@ -1,6 +1,6 @@
 ﻿/*
  * ListPorter - Upload standard or extended .m3u playlist files to Plex Media Server.
- * Copyright (C) 2020-2025 Richard Lawrence
+ * Copyright (C) 2020-2026 Richard Lawrence
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/ListPorter/Publish.ps1
+++ b/ListPorter/Publish.ps1
@@ -170,7 +170,7 @@ foreach ($arch in $architectures) {
 	& dotnet publish $csproj.FullName `
 		-c Release `
 		-r $arch `
-		--self-contained false `
+		--no-self-contained `
 		/p:PublishSingleFile=true `
 		/p:PublishTrimmed=false `
 		/p:IncludeNativeLibrariesForSelfExtract=false `

--- a/ListPorter/VersionHelper.cs
+++ b/ListPorter/VersionHelper.cs
@@ -1,6 +1,6 @@
 ﻿/*
  * ListPorter - Upload standard or extended .m3u playlist files to Plex Media Server.
- * Copyright (C) 2020-2025 Richard Lawrence
+ * Copyright (C) 2020-2026 Richard Lawrence
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ ListPorter currently meets the needs it was designed for, and no major new featu
 
 ## 🕰️ Version history
 
-### 1.1.2 (xx March 2026)
+### 1.1.2 (16 March 2026)
 - Fixed a bug where paths in playlists with accented or special characters could fail to match to content already in Plex due to UTF8 normalisation differences.
 - Fixed a bug where using `--unix` or `--windows` without `--find` or `--base-path` would incorrectly disable fuzzy matching.
 - Fixed a bug where some command line options weren't being correctly noted in the console/terminal output.

--- a/README.md
+++ b/README.md
@@ -265,8 +265,8 @@ ListPorter currently meets the needs it was designed for, and no major new featu
 ### 1.1.2 (xx March 2026)
 - Fixed a bug where paths in playlists with accented or special characters could fail to match to content already in Plex due to UTF8 normalisation differences.
 - Fixed a bug where using `--unix` or `--windows` without `--find` or `--base-path` would incorrectly disable fuzzy matching.
-- Fixed a bug where some command line options weren't being correctly noted in the console/terminal output
-- Forced SDK to 8.0.319 due to a known .NET SDK defect causing very large executables (see dotnet/sdk#51888) 
+- Fixed a bug where some command line options weren't being correctly noted in the console/terminal output.
+- Updated the publish script to use `--no-self-contained` as identifed by dotnet/sdk#51888.
 - Updated copyright.
 
 ### 1.1.1 (06 October 2025)

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ ListPorter currently meets the needs it was designed for, and no major new featu
 
 ### 1.1.2 (xx March 2026)
 - Fixed a bug where paths in playlists with accented or special characters could fail to match to content already in Plex due to UTF8 normalisation differences.
-- Fixed a bug where using `--unix` or `--windows` without `--find` or `--basepath` would incorrectly disable fuzzy matching.
+- Fixed a bug where using `--unix` or `--windows` without `--find` or `--base-path` would incorrectly disable fuzzy matching.
 - Fixed a bug where some command line options weren't being correctly noted in the console/terminal output
 - Updated copyright years. 
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ListPorter
 
 <p><img src="https://img.shields.io/badge/Windows-supported-0078D6?logo=windows&logoColor=white" alt="Windows"> <img src="https://img.shields.io/badge/Linux-supported-FCC624?logo=linux&logoColor=black" alt="Linux"> <img src="https://img.shields.io/badge/macOS-supported-000000?logo=apple&logoColor=white" alt="macOS"> <img src="https://img.shields.io/badge/.NET-C%23-512BD4?logo=dotnet&logoColor=white" alt=".NET/C#"> 
-<img src="https://img.shields.io/github/license/mrsilver76/listporter?logo=gnu&logoColor=white" alt="GPL License"> <img src="https://img.shields.io/github/downloads/mrsilver76/listporter/total" alt="total downloads"></p>
+<img src="https://img.shields.io/github/license/mrsilver76/listporter?logo=gnu&logoColor=white" alt="GPL License"> <img src="https://img.shields.io/github/stars/mrsilver76/listporter" alt="total stars"></p>
 
 _A cross-platform command-line tool (Windows, Linux, macOS) for importing standard or extended `.m3u` audio playlists into [Plex Media Server](https://www.plex.tv/media-server-downloads/). Supports fuzzy path matching, path rewriting, and optional mirroring._
 
@@ -266,7 +266,8 @@ ListPorter currently meets the needs it was designed for, and no major new featu
 - Fixed a bug where paths in playlists with accented or special characters could fail to match to content already in Plex due to UTF8 normalisation differences.
 - Fixed a bug where using `--unix` or `--windows` without `--find` or `--base-path` would incorrectly disable fuzzy matching.
 - Fixed a bug where some command line options weren't being correctly noted in the console/terminal output
-- Updated copyright years. 
+- Forced SDK to 8.0.319 due to a known .NET SDK defect causing very large executables (see dotnet/sdk#51888) 
+- Updated copyright.
 
 ### 1.1.1 (06 October 2025)
 - Output now confirms which Plex account or managed user the playlists will be uploaded to, based on the token provided.

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ ListPorter tries to match each file path in your playlist with the paths Plex ha
 
 This approach works well when root paths differ or when file systems vary across devices, as long as the layout near the file itself is consistent. However, if files have been renamed or stored with a different folder hierarchy, exact or fuzzy matching may fail.
 
-**If you use any of the options below to rewrite paths, fuzzy matching will be automatically disabled.** This is to avoid conflicts between automated and manual path handling.
+**Fuzzy matching is automatically disabled when using `-f` (`--find`) or `-b` (`--base-path`), as these options explicitly rewrite how paths are interpreted.** Other options, including `-w` (`--windows`) and `-u` (`--unix`) do not disable fuzzy matching because separator differences between Windows and Unix are handled automatically.
 
 These options don’t modify the playlist files themselves - they only affect how paths are interpreted during import.
 
@@ -262,10 +262,17 @@ ListPorter currently meets the needs it was designed for, and no major new featu
 
 ## 🕰️ Version history
 
+### 1.1.2 (xx March 2026)
+- Fixed a bug where paths in playlists with accented or special characters could fail to match to content already in Plex due to UTF8 normalisation differences.
+- Fixed a bug where using `--unix` or `--windows` without `--find` or `--basepath` would incorrectly disable fuzzy matching.
+- Fixed a bug where some command line options weren't being correctly noted in the console/terminal output
+- Updated copyright years. 
+
 ### 1.1.1 (06 October 2025)
 - Output now confirms which Plex account or managed user the playlists will be uploaded to, based on the token provided.
 - Fixed bug where logs were not being saved in the correct location.
 - Fixed bug where Plex token was being incorrectly saved in the logs.
+
 
 ### 1.1.0 (24 September 2025)
 - Added `-k` (`--update`) to force Plex to scan the library prior to importing.


### PR DESCRIPTION
- Fixed a bug where paths in playlists with accented or special characters could fail to match to content already in Plex due to UTF8 normalisation differences.
- Fixed a bug where using `--unix` or `--windows` without `--find` or `--base-path` would incorrectly disable fuzzy matching.
- Fixed a bug where some command line options weren't being correctly noted in the console/terminal output.
- Updated the publish script to use `--no-self-contained` as identifed by dotnet/sdk#51888.
- Updated copyright.